### PR TITLE
[basket_view] Fix problem with overwriting apof.egg-info

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: devel.dockerfile
     volumes:
-      - "./src/:/run/service/src"
+      - "./src/apof/:/run/service/src/apof"
       - "./media:/run/service/media"
       - "./fron/dist:/run/service/statics"
     ports:


### PR DESCRIPTION
It seems that there is no volume sync/bind during build.
That means that egg-info was in docker image but not in dev files. The sync/bind is "working" only during running, overwriting apof.egg-info.